### PR TITLE
chore: bump to crystal 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.35.1-alpine
+FROM crystallang/crystal:1.0.0-alpine
 
 WORKDIR /app
 
@@ -17,7 +17,7 @@ RUN apk add --no-cache bash
 
 COPY shard.yml /app
 
-RUN shards install
+RUN shards install --ignore-crystal-version
 
 COPY scripts /app/scripts
 COPY spec /app/spec

--- a/shard.lock
+++ b/shard.lock
@@ -2,19 +2,19 @@ version: 2.0
 shards:
   action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 3.5.2
+    version: 4.2.2
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.13.4
+    version: 0.14.1
 
   bisect:
     git: https://github.com/spider-gazelle/bisect.git
-    version: 1.2.0
+    version: 1.2.1
 
   connect-proxy:
     git: https://github.com/spider-gazelle/connect-proxy.git
-    version: 1.0.1
+    version: 1.2.1
 
   crc16:
     git: https://github.com/maiha/crc16.cr.git
@@ -25,16 +25,16 @@ shards:
     version: 0.3.0
 
   debug:
-    git: https://github.com/Sija/debug.cr.git
+    git: https://github.com/sija/debug.cr.git
     version: 2.0.0
 
   etcd:
     git: https://github.com/place-labs/crystal-etcd.git
-    version: 1.0.4
+    version: 1.1.2
 
   exec_from:
     git: https://github.com/place-labs/exec_from.git
-    version: 1.2.0
+    version: 1.2.1
 
   future:
     git: https://github.com/crystal-community/future.cr.git
@@ -42,23 +42,23 @@ shards:
 
   habitat:
     git: https://github.com/luckyframework/habitat.git
-    version: 0.4.4
+    version: 0.4.7
 
   hound-dog:
     git: https://github.com/place-labs/hound-dog.git
-    version: 2.6.0
+    version: 2.6.1
 
   ipaddress:
-    git: https://github.com/Sija/ipaddress.cr.git
+    git: https://github.com/sija/ipaddress.cr.git
     version: 0.2.1
 
   log_helper:
     git: https://github.com/spider-gazelle/log_helper.git
-    version: 1.0.2
+    version: 1.0.3
 
   lucky_router:
     git: https://github.com/luckyframework/lucky_router.git
-    version: 0.4.0
+    version: 0.4.1
 
   murmur3:
     git: https://github.com/aca-labs/murmur3.git
@@ -66,7 +66,11 @@ shards:
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 4.0.0
+    version: 5.0.5
+
+  placeos-log-backend:
+    git: https://github.com/place-labs/log-backend.git
+    version: 0.3.0
 
   pool:
     git: https://github.com/ysbaddaden/pool.git
@@ -74,14 +78,10 @@ shards:
 
   priority-queue:
     git: https://github.com/spider-gazelle/priority-queue.git
-    version: 1.0.0+git.commit.bde47d11cb4b4d1ed7680a7f417ff707c434b1e4
+    version: 1.0.1
 
   promise:
     git: https://github.com/spider-gazelle/promise.git
-    version: 2.2.1
-
-  protobuf:
-    git: https://github.com/jeromegn/protobuf.cr.git
     version: 2.2.2
 
   redis:
@@ -97,28 +97,28 @@ shards:
     version: 0.3.1
 
   retriable:
-    git: https://github.com/Sija/retriable.cr.git
-    version: 0.2.2
+    git: https://github.com/sija/retriable.cr.git
+    version: 0.2.3
 
   rwlock:
     git: https://github.com/spider-gazelle/readers-writer.git
-    version: 1.0.6
+    version: 1.0.7
 
   simple_retry:
     git: https://github.com/spider-gazelle/simple_retry.git
-    version: 1.1.0
+    version: 1.1.1
 
   ssh2:
     git: https://github.com/spider-gazelle/ssh2.cr.git
-    version: 1.5.1
+    version: 1.5.2
 
   tasker:
     git: https://github.com/spider-gazelle/tasker.git
-    version: 2.0.2
+    version: 2.0.3
 
   tokenizer:
     git: https://github.com/spider-gazelle/tokenizer.git
-    version: 1.1.0
+    version: 1.1.1
 
   ulid:
     git: https://github.com/place-labs/ulid.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,6 @@
 name: placeos-compiler
-version: 3.3.2
+version: 3.4.0
+crystal: ~> 1
 
 dependencies:
   placeos-driver:
@@ -16,3 +17,5 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+  placeos-log-backend:
+    github: place-labs/log-backend

--- a/spec/compiler_spec.cr
+++ b/spec/compiler_spec.cr
@@ -88,6 +88,7 @@ module PlaceOS
       )
 
       spec_executable = result[:executable]
+
       result[:exit_status].should eq(0)
       File.exists?(spec_executable).should be_true
 
@@ -111,6 +112,7 @@ module PlaceOS
         error: io
       ).exit_code
 
+      puts io.to_s if exit_code != 0
       exit_code.should eq(0)
 
       # Delete the file

--- a/spec/git_commands_spec.cr
+++ b/spec/git_commands_spec.cr
@@ -17,40 +17,40 @@ module PlaceOS::Compiler
     it "should list the revisions to a file in a repository" do
       changes = GitCommands.commits("shard.yml", 200, private_drivers)
       (changes.size > 0).should be_true
-      changes.map { |commit| commit[:subject] }.includes?("simplify dependencies").should be_true
+      changes.map(&.[:subject]).includes?("simplify dependencies").should be_true
     end
 
     it "should list the revisions of a repository" do
       changes = GitCommands.repository_commits(private_drivers, 200)
       (changes.size > 0).should be_true
-      changes.map { |commit| commit[:subject] }.includes?("simplify dependencies").should be_true
+      changes.map(&.[:subject]).includes?("simplify dependencies").should be_true
     end
 
     it "should checkout a particular revision of a file and then restore it" do
       # Check the current file
-      title = File.open(private_readme) { |file| file.gets('\n') }
+      title = File.open(private_readme, &.gets('\n'))
       title.should eq(current_title)
 
       # Process a particular commit
       GitCommands.checkout("README.md", "0bcfa6e4a9ad832fadf799f15f269608d61086a7", private_drivers) do
-        title = File.open(private_readme) { |file| file.gets('\n') }
+        title = File.open(private_readme, &.gets('\n'))
         title.should eq(old_title)
       end
 
       # File should have reverted
-      title = File.open(private_readme) { |file| file.gets('\n') }
+      title = File.open(private_readme, &.gets('\n'))
       title.should eq(current_title)
     end
 
     it "should checkout a file and then restore it on error" do
       # Check the current file
-      title = File.open(private_readme) { |file| file.gets('\n') }
+      title = File.open(private_readme, &.gets('\n'))
       title.should eq(current_title)
 
       # Process a particular commit
       expect_raises(Exception, "something went wrong") do
         GitCommands.checkout("README.md", "0bcfa6e4a9ad832fadf799f15f269608d61086a7", private_drivers) do
-          title = File.open(private_readme) { |file| file.gets('\n') }
+          title = File.open(private_readme, &.gets('\n'))
           title.should eq(old_title)
 
           raise "something went wrong"
@@ -58,7 +58,7 @@ module PlaceOS::Compiler
       end
 
       # File should have reverted
-      title = File.open(private_readme) { |file| file.gets('\n') }
+      title = File.open(private_readme, &.gets('\n'))
       title.should eq(current_title)
     end
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,6 @@
+require "placeos-log-backend"
+::Log.setup("*", backend: PlaceOS::LogBackend.log_backend, level: Log::Severity::Debug)
+
 require "spec"
 require "file_utils"
 

--- a/src/placeos-compiler/compiler.cr
+++ b/src/placeos-compiler/compiler.cr
@@ -128,7 +128,7 @@ module PlaceOS::Compiler
     # operations in a single lock. i.e. clone + shards install
     GitCommands.repo_lock(repo_dir).write do
       # First check if the dependencies are satisfied
-      result = ExecFrom.exec_from(repo_dir, "shards", {"--no-color", "check", "--production"})
+      result = ExecFrom.exec_from(repo_dir, "shards", {"--no-color", "check", "--ignore-crystal-version", "--production"})
       check_output = result[:output].to_s
       check_exit_code = result[:exit_code]
 
@@ -139,7 +139,7 @@ module PlaceOS::Compiler
         }
       else
         # Otherwise install shards
-        result = ExecFrom.exec_from(repo_dir, "shards", {"--no-color", "install", "--production"})
+        result = ExecFrom.exec_from(repo_dir, "shards", {"--no-color", "install", "--ignore-crystal-version", "--production"})
         {
           exit_status: result[:exit_code],
           output:      result[:output].to_s,


### PR DESCRIPTION
Adds `—ignore-crystal-version` to the internally run `shards install`