### PR TITLE
fix: better pulls via fetch and checkout

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-compiler
-version: 4.1.0
+version: 4.1.1
 crystal: ~> 1
 
 dependencies:

--- a/src/placeos-compiler/compiler.cr
+++ b/src/placeos-compiler/compiler.cr
@@ -220,14 +220,11 @@ module PlaceOS::Compiler
         raises: true,
       )
 
-      # Pull if already cloned and pull intended
+      # Pull if already cloned and pull instead (explicitly checkout latest HEAD)
       if clone_result.output.to_s.includes?("already exists") && pull_if_exists
-        Git.pull(
-          repository: repository,
-          working_directory: working_directory,
-          branch: branch,
-          raises: true,
-        )
+        Git.fetch(repository, working_directory)
+        Git.checkout_branch(branch, repository, working_directory)
+        Git._checkout(repository_path, "HEAD")
       end
 
       install_shards(repository, working_directory, shards_cache).tap do |result|

--- a/src/placeos-compiler/git.cr
+++ b/src/placeos-compiler/git.cr
@@ -116,8 +116,8 @@ module PlaceOS::Compiler
     end
 
     @[Deprecated("Use `Git.checkout_file` instead.")]
-    def self.checkout(**args)
-      checkout_file(**args)
+    def self.checkout(file : String, repository : String, working_directory : String, commit : String = "HEAD")
+      checkout_file(file, repository, working_directory, commit)
     end
 
     def self.checkout_file(file : String, repository : String, working_directory : String, commit : String = "HEAD")
@@ -134,10 +134,17 @@ module PlaceOS::Compiler
       end
     end
 
-    # Checkout a file relative to a directory
+    # Checkout a file relative to a repository
     protected def self._checkout_file(repository_directory : String, file : String, commit : String)
       operation_lock(repository_directory).synchronize do
         run_git(repository_directory, {"checkout", commit, "--", file}, raises: true)
+      end
+    end
+
+    # Checkout a repository to a commit
+    protected def self._checkout(repository_directory : String, commit : String)
+      operation_lock(repository_directory).synchronize do
+        run_git(repository_directory, {"checkout", commit}, raises: true)
       end
     end
 


### PR DESCRIPTION
Implements a more sane pull method via...
1. a fetch (gets the commits on the remote)
1. a checkout (checkouts any available commit, or `HEAD` if unspecified)

Closes #15 