### PR TITLE
feat(compiler): limit build to a single thread

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-compiler
-version: 4.3.1
+version: 4.3.2
 crystal: ">= 1.0.0"
 license: MIT
 

--- a/src/placeos-compiler/compiler.cr
+++ b/src/placeos-compiler/compiler.cr
@@ -123,7 +123,7 @@ module PlaceOS::Compiler
     multithreaded : Bool,
     shards_cache : String?
   ) : ExecFrom::Result
-    arguments = ["build", "--static", "--no-color", "--error-trace", "-o", executable_path, build_script]
+    arguments = ["build", "--static", "--no-color", "--error-trace", "--threads", "1", "-o", executable_path, build_script]
     arguments.insert(1, "--debug") if debug
     arguments.insert(1, "--release") if release
     arguments.insert(1, "--Dpreview_mt") if multithreaded

--- a/src/placeos-compiler/compiler.cr
+++ b/src/placeos-compiler/compiler.cr
@@ -39,7 +39,8 @@ module PlaceOS::Compiler
     debug : Bool = false,
     release : Bool = false,
     multithreaded : Bool = false,
-    shards_cache : String? = nil
+    shards_cache : String? = nil,
+    build_threads : Int32 = 1
   ) : Result::Build
     # Ensure the bin directory exists
     Dir.mkdir_p binary_directory
@@ -77,6 +78,7 @@ module PlaceOS::Compiler
         release:             release,
         multithreaded:       multithreaded,
         shards_cache:        shards_cache,
+        build_threads:       build_threads.to_s,
       }
 
       # When developing you may not want to have to commit
@@ -121,9 +123,10 @@ module PlaceOS::Compiler
     debug : Bool,
     release : Bool,
     multithreaded : Bool,
-    shards_cache : String?
+    shards_cache : String?,
+    build_threads : String
   ) : ExecFrom::Result
-    arguments = ["build", "--static", "--no-color", "--error-trace", "--threads", "1", "-o", executable_path, build_script]
+    arguments = ["build", "--static", "--no-color", "--error-trace", "--threads", build_threads, "-o", executable_path, build_script]
     arguments.insert(1, "--debug") if debug
     arguments.insert(1, "--release") if release
     arguments.insert(1, "--Dpreview_mt") if multithreaded

--- a/src/placeos-compiler/compiler.cr
+++ b/src/placeos-compiler/compiler.cr
@@ -78,7 +78,7 @@ module PlaceOS::Compiler
         release:             release,
         multithreaded:       multithreaded,
         shards_cache:        shards_cache,
-        build_threads:       build_threads.to_s,
+        build_threads:       build_threads,
       }
 
       # When developing you may not want to have to commit
@@ -124,9 +124,9 @@ module PlaceOS::Compiler
     release : Bool,
     multithreaded : Bool,
     shards_cache : String?,
-    build_threads : String
+    build_threads : Int32
   ) : ExecFrom::Result
-    arguments = ["build", "--static", "--no-color", "--error-trace", "--threads", build_threads, "-o", executable_path, build_script]
+    arguments = ["build", "--static", "--no-color", "--error-trace", "--threads", build_threads.to_s, "-o", executable_path, build_script]
     arguments.insert(1, "--debug") if debug
     arguments.insert(1, "--release") if release
     arguments.insert(1, "--Dpreview_mt") if multithreaded


### PR DESCRIPTION
defaults to forking 8 processes which requires a lot of memory and due to limited resources on a lot of deployments, leads to swap thrashing and lower performance. On a server with 16GB of RAM we saw a significant increase in compilation times and lower resource usage when using `--threads 1`