### PR TITLE
fix(git): return full commit history, not just up to HEAD

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-compiler
-version: 4.6.0
+version: 4.7.0
 crystal: ">= 1.0.0"
 license: MIT
 

--- a/spec/git_spec.cr
+++ b/spec/git_spec.cr
@@ -17,16 +17,54 @@ module PlaceOS::Compiler
       files.includes?("shard.yml").should be_true
     end
 
-    it "should list the revisions to a file in a repository" do
-      changes = Git.commits("shard.yml", repository, working_directory, 200)
-      changes.should_not be_empty
-      changes.map(&.subject).includes?("simplify dependencies").should be_true
+    describe ".commits" do
+      it "lists the revisions of a file in a repository" do
+        changes = Git.commits("shard.yml", repository, working_directory, 200)
+        changes.should_not be_empty
+        changes.map(&.subject).should contain("simplify dependencies")
+      end
+
+      it "fetches entire commit history of a file on a branch" do
+        repository = "compiler"
+        repository_uri = "https://github.com/placeos/compiler"
+        branch = "test-fixture"
+        checked_out_commit = "f7c6d8fb810c2be78722249e06bbfbda3d30d355"
+        expected_commit = "d37c34a49c96a2559408468b2b9458867cbf1329"
+        repository_directory = File.join(working_directory, repository)
+        Git.clone(
+          repository: repository,
+          repository_uri: repository_uri,
+          working_directory: working_directory,
+        )
+        Git._checkout(repository_directory, checked_out_commit)
+        changes = Git.commits("README.md", repository, working_directory, 200, branch)
+        changes.map(&.commit).should contain(expected_commit)
+      end
     end
 
-    it "should list the revisions of a repository" do
-      changes = Git.repository_commits(repository, working_directory, 200)
-      changes.should_not be_empty
-      changes.map(&.subject).includes?("simplify dependencies").should be_true
+    describe ".repository_commits" do
+      it "lists the revisions of a repository" do
+        changes = Git.repository_commits(repository, working_directory, 200)
+        changes.should_not be_empty
+        changes.map(&.subject).includes?("simplify dependencies").should be_true
+      end
+
+      it "fetches entire commit history of a branch" do
+        repository = "compiler"
+        repository_uri = "https://github.com/placeos/compiler"
+        branch = "test-fixture"
+        checked_out_commit = "f7c6d8fb810c2be78722249e06bbfbda3d30d355"
+        expected_commit = "d37c34a49c96a2559408468b2b9458867cbf1329"
+        repository_directory = File.join(working_directory, repository)
+        Git.clone(
+          repository: repository,
+          repository_uri: repository_uri,
+          working_directory: working_directory,
+        )
+        Git._checkout(repository_directory, checked_out_commit)
+        changes = Git.repository_commits(repository, working_directory, 200, branch)
+        changes.map(&.commit).should contain(expected_commit)
+      end
     end
 
     describe "remote url" do

--- a/spec/git_spec.cr
+++ b/spec/git_spec.cr
@@ -25,19 +25,19 @@ module PlaceOS::Compiler
       end
 
       it "fetches entire commit history of a file on a branch" do
-        repository = "compiler"
-        repository_uri = "https://github.com/placeos/compiler"
+        repo = "compiler"
+        repo_uri = "https://github.com/placeos/compiler"
         branch = "test-fixture"
         checked_out_commit = "f7c6d8fb810c2be78722249e06bbfbda3d30d355"
         expected_commit = "d37c34a49c96a2559408468b2b9458867cbf1329"
-        repository_directory = File.join(working_directory, repository)
+        repository_directory = File.join(working_directory, repo)
         Git.clone(
-          repository: repository,
-          repository_uri: repository_uri,
+          repository: repo,
+          repository_uri: repo_uri,
           working_directory: working_directory,
         )
         Git._checkout(repository_directory, checked_out_commit)
-        changes = Git.commits("README.md", repository, working_directory, 200, branch)
+        changes = Git.commits("README.md", repo, working_directory, 200, branch)
         changes.map(&.commit).should contain(expected_commit)
       end
     end
@@ -50,19 +50,19 @@ module PlaceOS::Compiler
       end
 
       it "fetches entire commit history of a branch" do
-        repository = "compiler"
-        repository_uri = "https://github.com/placeos/compiler"
+        repo = "compiler"
+        repo_uri = "https://github.com/placeos/compiler"
         branch = "test-fixture"
         checked_out_commit = "f7c6d8fb810c2be78722249e06bbfbda3d30d355"
         expected_commit = "d37c34a49c96a2559408468b2b9458867cbf1329"
-        repository_directory = File.join(working_directory, repository)
+        repository_directory = File.join(working_directory, repo)
         Git.clone(
-          repository: repository,
-          repository_uri: repository_uri,
+          repository: repo,
+          repository_uri: repo_uri,
           working_directory: working_directory,
         )
         Git._checkout(repository_directory, checked_out_commit)
-        changes = Git.repository_commits(repository, working_directory, 200, branch)
+        changes = Git.repository_commits(repo, working_directory, 200, branch)
         changes.map(&.commit).should contain(expected_commit)
       end
     end

--- a/src/placeos-compiler/git.cr
+++ b/src/placeos-compiler/git.cr
@@ -56,7 +56,14 @@ module PlaceOS::Compiler
     end
 
     def self.commits(file_name : String | Array(String), repository : String, working_directory : String, count : Int32 = 50) : Array(Commit)
-      base_arguments = ["log", "--format=format:%H%n%cI%n%an%n%s%n<--%n%n-->", "--no-color", "-n", count.to_s, "--"]
+      base_arguments = [
+        "log",
+        "--format=format:%h%n%cI%n%an%n%s%n<--%n%n-->",
+        "--no-color",
+        "-n", count.to_s,
+        "origin",
+        "--",
+      ]
       arguments = base_arguments + (file_name.is_a?(String) ? [file_name] : file_name)
 
       # https://git-scm.com/docs/pretty-formats


### PR DESCRIPTION
Render all commits on origin, not just up to the currently checked out HEAD

Fixes #41 