### PR TITLE
fix(git): commit listing is a read operation

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-compiler
-version: 4.7.0
+version: 4.7.1
 crystal: ">= 1.0.0"
 license: MIT
 

--- a/src/placeos-compiler/git.cr
+++ b/src/placeos-compiler/git.cr
@@ -33,7 +33,7 @@ module PlaceOS::Compiler
       # %cI: committer date, strict ISO 8601 format
       # %an: author name
       # %s: subject
-      result = repository_lock(path).write do
+      result = repository_lock(path).read do
         run_git(path, {"fetch", "--all"})
         run_git(
           path,
@@ -69,7 +69,7 @@ module PlaceOS::Compiler
       # %an: author name
       # %s: subject
       path = repository_path(repository, working_directory)
-      result = file_operation(path, file_name) do
+      result = repository_lock(path).read do
         run_git(path, {"fetch", "--all"})
         run_git(path, arguments, git_args: {"--no-pager"}, raises: true)
       end


### PR DESCRIPTION
A `write` lock was used when listing commits in a repository, this should have been a `read`