### PR TITLE
fix(git): current commits

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-compiler
-version: 4.7.1
+version: 4.8.0
 crystal: ">= 1.0.0"
 license: MIT
 

--- a/spec/git_spec.cr
+++ b/spec/git_spec.cr
@@ -3,15 +3,16 @@ require "yaml"
 
 module PlaceOS::Compiler
   describe Git do
-    repository = "private_drivers"
     working_directory = Compiler.repository_dir
+    repository = "private_drivers"
     repository_path = Git.repository_path(repository, working_directory)
     readme = File.join(repository_path, "README.md")
 
     before_each do
-      if Dir.exists? repository_path
-        Git._restore(repository_path, "master")
-      end
+      repository = "private_drivers"
+      working_directory = Compiler.repository_dir
+      repository_path = Git.repository_path(repository, working_directory)
+      Git._checkout(repository_path, "master", force: true) if Dir.exists? repository_path
     end
 
     current_title = "# Private PlaceOS Drivers\n"
@@ -31,19 +32,19 @@ module PlaceOS::Compiler
       end
 
       it "fetches entire commit history of a file on a branch" do
-        repo = "compiler"
-        repo_uri = "https://github.com/placeos/compiler"
+        repository = "compiler"
+        repository_uri = "https://github.com/placeos/compiler"
         branch = "test-fixture"
         checked_out_commit = "f7c6d8fb810c2be78722249e06bbfbda3d30d355"
         expected_commit = "d37c34a49c96a2559408468b2b9458867cbf1329"
-        repository_directory = File.join(working_directory, repo)
+        repository_path = File.join(working_directory, repository)
         Git.clone(
-          repository: repo,
-          repository_uri: repo_uri,
+          repository: repository,
+          repository_uri: repository_uri,
           working_directory: working_directory,
         )
-        Git._checkout(repository_directory, checked_out_commit)
-        changes = Git.commits("README.md", repo, working_directory, 200, branch)
+        Git._checkout(repository_path, checked_out_commit)
+        changes = Git.commits("README.md", repository, working_directory, 200, branch)
         changes.map(&.commit).should contain(expected_commit)
       end
     end
@@ -56,19 +57,15 @@ module PlaceOS::Compiler
       end
 
       it "fetches entire commit history of a branch" do
-        repo = "compiler"
-        repo_uri = "https://github.com/placeos/compiler"
+        repository = "compiler"
+        repository_uri = "https://github.com/placeos/compiler"
         branch = "test-fixture"
         checked_out_commit = "f7c6d8fb810c2be78722249e06bbfbda3d30d355"
         expected_commit = "d37c34a49c96a2559408468b2b9458867cbf1329"
-        repository_directory = File.join(working_directory, repo)
-        Git.clone(
-          repository: repo,
-          repository_uri: repo_uri,
-          working_directory: working_directory,
-        )
-        Git._checkout(repository_directory, checked_out_commit)
-        changes = Git.repository_commits(repo, working_directory, 200, branch)
+        repository_path = File.join(working_directory, repository)
+        Git.clone(repository: repository, repository_uri: repository_uri, working_directory: working_directory)
+        Git._checkout(repository_path, checked_out_commit)
+        changes = Git.repository_commits(repository, working_directory, 200, branch)
         changes.map(&.commit).should contain(expected_commit)
       end
     end

--- a/spec/git_spec.cr
+++ b/spec/git_spec.cr
@@ -87,18 +87,18 @@ module PlaceOS::Compiler
     describe ".current_repository_commit" do
       it "fetches checked out commit of repo" do
         expected_commit = "0bcfa6e4a9ad832fadf799f15f269608d61086a7"
-        path = File.join(working_directory, repository)
-        Git._checkout(path, expected_commit)
+        Git._checkout(repository_path, expected_commit)
         Git.current_repository_commit(repository, working_directory).should eq expected_commit
       end
     end
+
     describe ".current_file_commit" do
       it "fetches checked out commit of file" do
         file = "README.md"
-        expected_commit = "0bcfa6e4a9ad832fadf799f15f269608d61086a7"
-        Git.checkout_file(file, repository, working_directory, commit: expected_commit) do
-          Git.current_file_commit(file, repository, working_directory).should eq expected_commit
-        end
+        checked_out_commit = "fe335884cbb8d7bc843d33fa7b97d7a306b35208"
+        expected_commit = "121a3593dbf1b83373d11e8ff8f1150c14e67fe9"
+        Git._checkout(repository_path, checked_out_commit)
+        Git.current_file_commit(file, repository, working_directory).should eq expected_commit
       end
     end
 
@@ -149,7 +149,7 @@ module PlaceOS::Compiler
       it "will check out a file, then restore to a repo state where it does not exist" do
         file = "drivers/aca/private_helper.cr"
         path = File.join(repository_path, file)
-        File.exists?(path).should be_false
+        File.exists?(repository_path).should be_false
 
         Git.checkout_file(file, repository, working_directory, commit: "9e5c982e2aac06e1e10349fe8352109c138d7f23") do
           File.exists?(path).should be_true

--- a/spec/git_spec.cr
+++ b/spec/git_spec.cr
@@ -8,6 +8,12 @@ module PlaceOS::Compiler
     repository_path = Git.repository_path(repository, working_directory)
     readme = File.join(repository_path, "README.md")
 
+    before_each do
+      if Dir.exists? repository_path
+        Git._restore(repository_path, "master")
+      end
+    end
+
     current_title = "# Private PlaceOS Drivers\n"
     old_title = "# Private Engine Drivers\n"
 

--- a/spec/git_spec.cr
+++ b/spec/git_spec.cr
@@ -84,6 +84,24 @@ module PlaceOS::Compiler
       end
     end
 
+    describe ".current_repository_commit" do
+      it "fetches checked out commit of repo" do
+        expected_commit = "0bcfa6e4a9ad832fadf799f15f269608d61086a7"
+        path = File.join(working_directory, repository)
+        Git._checkout(path, expected_commit)
+        Git.current_repository_commit(repository, working_directory).should eq expected_commit
+      end
+    end
+    describe ".current_file_commit" do
+      it "fetches checked out commit of file" do
+        file = "README.md"
+        expected_commit = "0bcfa6e4a9ad832fadf799f15f269608d61086a7"
+        Git.checkout_file(file, repository, working_directory, commit: expected_commit) do
+          Git.current_file_commit(file, repository, working_directory).should eq expected_commit
+        end
+      end
+    end
+
     describe ".branches" do
       it "lists branches" do
         branches = Git.branches(repository, working_directory)

--- a/spec/git_spec.cr
+++ b/spec/git_spec.cr
@@ -149,7 +149,7 @@ module PlaceOS::Compiler
       it "will check out a file, then restore to a repo state where it does not exist" do
         file = "drivers/aca/private_helper.cr"
         path = File.join(repository_path, file)
-        File.exists?(repository_path).should be_false
+        File.exists?(path).should be_false
 
         Git.checkout_file(file, repository, working_directory, commit: "9e5c982e2aac06e1e10349fe8352109c138d7f23") do
           File.exists?(path).should be_true


### PR DESCRIPTION
#43 broke the implicit behaviour of `current_commit` for repository and files.
This PR fixes that by introducing the ability to drop the `branch` param (pass `nil`) to get the log of the current repo state.